### PR TITLE
chore: Added documentation in the build-apk so that devs using puro or fvm can run the command

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -39,7 +39,7 @@ scripts:
     exec: dart run slang
 
   build-apk:
-    description: Builds the APK File
+    description: Builds the APK File. If you're using puro or fvm, then make sure to add `puro` or `fvm` before running the command
     packageFilters:
       flutter: true
       dirExists: lib


### PR DESCRIPTION


<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
As of now, the `melos run build-apk` command is using 
<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [X] 🗑️ Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the description of the build-apk script to advise users to prepend the command with `puro` or `fvm` if they are using those tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->